### PR TITLE
Fix Docker quick-start configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,12 @@ docker-compose up -d
 
 应用默认运行在 `http://localhost:3000`。
 
+Docker Compose 会等待 PostgreSQL 就绪后再启动应用。默认数据库密码仅适合本地开发；部署到共享或公网环境前，请设置一个新密码：
+
+```bash
+POSTGRES_PASSWORD='替换为安全密码' docker-compose up -d
+```
+
 ---
 
 > 如需部署 Next.js 版本，请前往 [forumlify/tree/next](https://github.com/furrium/forumlify/tree/next)。
@@ -62,7 +68,7 @@ psql -U forumlify -d forumlify -f schema.sql
 
 | 变量 | 默认值 | 说明 |
 |------|--------|------|
-| `DATABASE_URL` | `postgresql://forumlify:123456@localhost:5432/forumlify` | PostgreSQL 连接串 |
+| `DATABASE_URL` | `postgresql://forumlify:123456@localhost:5432/forumlify` | PostgreSQL 连接串，本地默认密码为 `123456` |
 | `PORT` | `3000` | HTTP 监听端口 |
 | `JWT_SECRET` | `forumlify-secret-key-change-me-in-production` | JWT 签名密钥，**生产环境务必修改** |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,25 +1,30 @@
-version: '3'
 services:
   db:
     image: postgres:15
     environment:
       POSTGRES_USER: forumlify
-      POSTGRES_PASSWORD: 123456
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-123456}
       POSTGRES_DB: forumlify
     volumes:
       - ./schema.sql:/docker-entrypoint-initdb.d/schema.sql
       - db_data:/var/lib/postgresql/data
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U forumlify -d forumlify"]
+      interval: 5s
+      timeout: 5s
+      retries: 10
 
   app:
     build: .
     ports:
-      - "3003:3000"
+      - "3000:3000"
     depends_on:
-      - db
+      db:
+        condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://forumlify:123456@db:5432/forumlify
+      DATABASE_URL: postgresql://forumlify:${POSTGRES_PASSWORD:-123456}@db:5432/forumlify
     volumes:
       - ./uploads:/app/uploads
 


### PR DESCRIPTION
Superseded by #13, which includes the credential/port/health fixes plus canonical Dockerfile naming, migrations, non-root image hardening, readiness, persistent uploads, and graceful shutdown.