### PR TITLE
Fix registration and recovery-code setup

### DIFF
--- a/js/auth.js
+++ b/js/auth.js
@@ -1,16 +1,4 @@
 // ============================================================
-//  AUTH 对象（供其他模块使用）
-// ============================================================
-
-const AUTH = {
-  async getUserProfile(userId) {
-    const data = await apiFetch('/users/' + userId);
-    if (data.error) throw new Error(data.error);
-    return data;
-  }
-};
-
-// ============================================================
 //  🔐 认证
 // ============================================================
 
@@ -60,39 +48,43 @@ document.getElementById('registerSubmit').addEventListener('click', async () => 
   if (password.length < 6) { alert('密码至少6位'); return; }
   if (parseInt(captchaInput) !== captchaAnswer) { alert('验证码错误，请重新计算'); refreshCaptcha('reg'); return; }
   try {
-    const result = await API.register(email, password, username);
-    document.getElementById('registerModal').classList.remove('active');
-    document.getElementById('regUsername').value = '';
-    document.getElementById('regEmail').value = '';
-    document.getElementById('regPassword').value = '';
-    document.getElementById('regCaptchaInput').value = '';
-    alert('注册成功！请登录');
-
-    // 生成恢复码
-    try {
-      const recoveryData = await API.generateRecoveryCodes();
-      if (recoveryData.codes) {
-        showRecoveryCodesModal(recoveryData.codes);
-      }
-    } catch (e) {
-      console.warn('恢复码生成失败:', e);
-    }
-
-    const loginResult = await API.login(email, password);
-    if (loginResult.user) {
-      const profile = await AUTH.getUserProfile(loginResult.user.id);
-      currentUser = { ...loginResult.user, ...profile };
-      API.logEvent('register').catch(() => {});
-      renderNav();
-      if (currentPage === 'admin' && currentUser.role !== 'admin') {
-        switchPage('feed');
-      } else if (currentPage === 'feed') {
-        renderFeed();
-        renderStats();
-      }
-    }
+    await API.register(email, password, username);
   } catch (err) {
     alert('注册失败：' + err.message);
+    return;
+  }
+
+  document.getElementById('registerModal').classList.remove('active');
+  document.getElementById('regUsername').value = '';
+  document.getElementById('regEmail').value = '';
+  document.getElementById('regPassword').value = '';
+  document.getElementById('regCaptchaInput').value = '';
+
+  try {
+    await API.login(email, password);
+    currentUser = await API.getMe();
+    API.logEvent('register').catch(() => {});
+    renderNav();
+
+    if (currentPage === 'admin' && currentUser.role !== 'admin') {
+      switchPage('feed');
+    } else if (currentPage === 'feed') {
+      renderFeed();
+      renderStats();
+    }
+  } catch (err) {
+    alert('注册成功，但自动登录失败，请手动登录：' + err.message);
+    return;
+  }
+
+  try {
+    const recoveryData = await API.generateRecoveryCodes();
+    if (recoveryData.codes?.length) {
+      showRecoveryCodesModal(recoveryData.codes);
+    }
+  } catch (err) {
+    console.warn('恢复码生成失败:', err);
+    alert('注册并登录成功，但恢复码生成失败。请稍后在设置中重新生成。');
   }
 });
 


### PR DESCRIPTION
## Summary
- authenticate before calling the protected recovery-code endpoint
- load the current profile through the existing `/api/auth/me` API
- remove the client call to the nonexistent `GET /api/users/:id` endpoint
- report registration, automatic-login, and recovery setup failures separately

## Validation
- `node --check` for every tracked JavaScript file
- flow assertion verifies register ? login ? getMe ? recovery-code ordering
- `git diff --check`