### PR TITLE
Repair frontend runtime flows

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,7 +129,7 @@
   <!-- 设置页面 -->
   <div id="pageSettings" class="page-slide">
     <div class="page-header" style="max-width:1200px;margin:0 auto;width:100%;">
-      <button class="back-btn" onclick="switchPage('feed')">
+      <button class="back-btn">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
         返回
       </button>
@@ -177,7 +177,7 @@
   <!-- 管理后台 -->
   <div id="pageAdmin" class="page-slide">
     <div class="page-header" style="max-width:1200px;margin:0 auto;width:100%;">
-      <button class="back-btn" onclick="switchPage('feed')">
+      <button class="back-btn">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
         返回
       </button>
@@ -272,7 +272,7 @@
   <!-- 帖子详情页 -->
   <div id="pagePost" class="page-slide">
     <div class="page-header" style="max-width:1200px;margin:0 auto;width:100%;">
-      <button class="back-btn" onclick="switchPage('feed')">
+      <button class="back-btn">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
         返回
       </button>
@@ -324,7 +324,7 @@
   <!-- 用户主页 -->
   <div id="pageUser" class="page-slide">
     <div class="page-header" style="max-width:700px;margin:0 auto;width:100%;">
-      <button class="back-btn" onclick="switchPage('feed')">
+      <button class="back-btn">
         <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="15 18 9 12 15 6"/></svg>
         返回
       </button>

--- a/js/admin.js
+++ b/js/admin.js
@@ -719,7 +719,7 @@ function openCustomPageEditor(page) {
       if (isEdit) {
         await API.updateCustomPage(page.id, title, content, enabled);
       } else {
-        await API.createCustomPage(name, title, content);
+        await API.createCustomPage(name, title, content, enabled);
       }
       modal.remove();
       loadCustomPageList();

--- a/js/api.js
+++ b/js/api.js
@@ -3,7 +3,7 @@
 // ============================================================
 let token = localStorage.getItem('forumlify-token') || null;
 
-function apiFetch(path, options = {}) {
+async function apiFetch(path, options = {}) {
   const url = CONFIG.API_BASE_URL + path;
   const headers = {
     'Content-Type': 'application/json',
@@ -12,10 +12,25 @@ function apiFetch(path, options = {}) {
   if (token) {
     headers['Authorization'] = 'Bearer ' + token;
   }
-  return fetch(url, {
+
+  const response = await fetch(url, {
     ...options,
     headers
-  }).then(res => res.json());
+  });
+  const contentType = response.headers.get('content-type') || '';
+  let data;
+
+  if (contentType.includes('application/json')) {
+    data = await response.json();
+  } else {
+    const text = await response.text();
+    data = { error: text.trim() || `请求失败 (${response.status})` };
+  }
+
+  if (!response.ok) {
+    throw new Error(data.error || `请求失败 (${response.status})`);
+  }
+  return data;
 }
 
 const API = {
@@ -303,10 +318,10 @@ const API = {
     return data || [];
   },
 
-  async createCustomPage(name, title, content) {
+  async createCustomPage(name, title, content, enabled) {
     const data = await apiFetch('/admin/custom-pages', {
       method: 'POST',
-      body: JSON.stringify({ name, title, content })
+      body: JSON.stringify({ name, title, content, enabled })
     });
     if (data.error) throw new Error(data.error);
     return data;
@@ -381,18 +396,6 @@ const API = {
     const data = await apiFetch('/users/' + currentUser.id + '/email', {
       method: 'PUT',
       body: JSON.stringify({ password, newEmail })
-    });
-    if (data.error) throw new Error(data.error);
-    return data;
-  },
-
-  // ============================================================
-  //  置顶
-  // ============================================================
-
-  async togglePinPost(postId) {
-    const data = await apiFetch('/posts/' + postId + '/pin', {
-      method: 'PUT'
     });
     if (data.error) throw new Error(data.error);
     return data;

--- a/js/app.js
+++ b/js/app.js
@@ -69,14 +69,19 @@ async function loadForumName() {
   }
 }
 
-function switchPage(page, param) {
+function switchPage(page, param, { historyMode = 'push' } = {}) {
   const url = new URL(window.location);
+  const updateHistory = state => {
+    if (historyMode === 'none') return;
+    const method = historyMode === 'replace' ? 'replaceState' : 'pushState';
+    window.history[method](state, '', url);
+  };
 
   if (page === 'user' && param) {
     url.searchParams.set('user', param);
     url.searchParams.delete('page');
     url.searchParams.delete('post');
-    window.history.pushState({ page: 'user', username: param }, '', url);
+    updateHistory({ page: 'user', username: param });
     showUserPage(param);
     return;
   }
@@ -85,7 +90,7 @@ function switchPage(page, param) {
     url.searchParams.set('post', param);
     url.searchParams.delete('page');
     url.searchParams.delete('user');
-    window.history.pushState({ page: 'post', postId: param }, '', url);
+    updateHistory({ page: 'post', postId: param });
     showPostPage(param);
     return;
   }
@@ -95,7 +100,7 @@ function switchPage(page, param) {
     url.searchParams.delete('page');
     url.searchParams.delete('post');
     url.searchParams.delete('user');
-    window.history.pushState({ page: 'custom', custom: param }, '', url);
+    updateHistory({ page: 'custom', custom: param });
     showCustomPage(param);
     return;
   }
@@ -111,7 +116,7 @@ function switchPage(page, param) {
     url.searchParams.delete('user');
     url.searchParams.delete('custom');
   }
-  window.history.pushState({ page: page }, '', url);
+  updateHistory({ page: page });
 
   document.getElementById('app').style.display = 'none';
   document.querySelectorAll('.page-slide').forEach(el => {
@@ -630,8 +635,8 @@ async function renderSettingsPage(tab = 'profile') {
   const user = currentUser;
 
   try {
-    const userPosts = await apiFetch('/posts?user_id=' + user.id);
-    const postCount = userPosts.data ? userPosts.data.length : 0;
+    const userPosts = await apiFetch('/posts?user_id=' + user.id + '&page=1&limit=1');
+    const postCount = userPosts.pagination?.total || 0;
 
     let recoveryCount = 0;
     try {
@@ -852,34 +857,20 @@ async function renderSettingsPage(tab = 'profile') {
         <div style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:20px;">
           <p style="font-size:14px;color:var(--text-secondary);margin-bottom:12px;">用于忘记密码时重置账户。每个恢复码只能使用一次。</p>
           <div style="display:flex;gap:8px;flex-wrap:wrap;">
-            <button id="viewRecoveryCodesBtn" class="btn-secondary" style="padding:8px 16px;border:1px solid var(--border);border-radius:4px;background:var(--surface);cursor:pointer;color:var(--text);">${getIcon('list')} 查看恢复码</button>
-            <button id="regenerateRecoveryCodesBtn" class="btn-secondary" style="padding:8px 16px;border:1px solid var(--border);border-radius:4px;background:var(--surface);cursor:pointer;color:var(--text);">${getIcon('refresh')} 重新生成</button>
+            <button id="regenerateRecoveryCodesBtn" class="btn-secondary" style="padding:8px 16px;border:1px solid var(--border);border-radius:4px;background:var(--surface);cursor:pointer;color:var(--text);">${getIcon('refresh')} ${recoveryCount > 0 ? '替换恢复码' : '生成恢复码'}</button>
           </div>
+          <p style="font-size:12px;color:var(--text-light);margin-top:8px;">恢复码仅在生成时显示，之后无法再次查看。</p>
           <div id="recoveryCodesStatus" style="font-size:13px;color:var(--text-light);margin-top:8px;">剩余 ${recoveryCount} 个可用恢复码</div>
         </div>
       `;
 
       // ===== 恢复码管理 =====
-      const viewBtn = document.getElementById('viewRecoveryCodesBtn');
       const regenBtn = document.getElementById('regenerateRecoveryCodesBtn');
       const recoveryStatus = document.getElementById('recoveryCodesStatus');
 
-      if (viewBtn) {
-        viewBtn.addEventListener('click', async function() {
-          try {
-            const data = await API.generateRecoveryCodes();
-            showRecoveryCodesModal(data.codes);
-            const countData = await API.getRecoveryCodesCount();
-            if (recoveryStatus) recoveryStatus.textContent = '剩余 ' + (countData.count || 0) + ' 个可用恢复码';
-          } catch (err) {
-            alert('获取恢复码失败：' + err.message);
-          }
-        });
-      }
-
       if (regenBtn) {
         regenBtn.addEventListener('click', async function() {
-          if (!confirm('重新生成将替换所有旧的恢复码，确定继续吗？')) return;
+          if (recoveryCount > 0 && !confirm('生成新恢复码将使所有旧恢复码失效，确定继续吗？')) return;
           try {
             const data = await API.generateRecoveryCodes();
             showRecoveryCodesModal(data.codes);
@@ -1115,19 +1106,19 @@ async function init() {
   }
 
   if (customParam) {
-    showCustomPage(customParam);
+    switchPage('custom', customParam, { historyMode: 'replace' });
   } else if (userParam) {
-    showUserPage(userParam);
+    switchPage('user', userParam, { historyMode: 'replace' });
   } else if (postParam) {
-    showPostPage(postParam);
+    switchPage('post', postParam, { historyMode: 'replace' });
   } else if (pageParam && ['messages', 'settings', 'admin', 'new'].includes(pageParam)) {
     if (pageParam === 'admin' && currentUser?.role !== 'admin') {
-      switchPage('feed');
+      switchPage('feed', null, { historyMode: 'replace' });
     } else {
-      switchPage(pageParam);
+      switchPage(pageParam, null, { historyMode: 'replace' });
     }
   } else {
-    switchPage('feed');
+    switchPage('feed', null, { historyMode: 'replace' });
   }
 
   // ============================================================
@@ -1330,13 +1321,13 @@ async function init() {
     const username = state.username || null;
     const custom = state.custom || null;
     if (postId) {
-      showPostPage(postId);
+      switchPage('post', postId, { historyMode: 'none' });
     } else if (username) {
-      showUserPage(username);
+      switchPage('user', username, { historyMode: 'none' });
     } else if (custom) {
-      showCustomPage(custom);
+      switchPage('custom', custom, { historyMode: 'none' });
     } else {
-      switchPage(page);
+      switchPage(page, null, { historyMode: 'none' });
     }
   });
 

--- a/js/feed.js
+++ b/js/feed.js
@@ -206,30 +206,6 @@ function renderFeed() {
   });
 }
 
-function renderStats() {
-  API.getStats().then(stats => {
-    document.getElementById('statTopics').textContent = stats.topics || 0;
-    document.getElementById('statPosts').textContent = stats.posts || 0;
-    document.getElementById('statUsers').textContent = stats.users || 0;
-    // 在线人数已移除
-  }).catch(() => {});
-}
-
-function renderLinks() {
-  API.getLinks().then(links => {
-    const ul = document.getElementById('friendlyLinks');
-    if (!links || links.length === 0) {
-      ul.innerHTML = '<li style="color:#94a3b8;font-size:13px;">暂无链接</li>';
-      return;
-    }
-    let html = '';
-    links.forEach(l => {
-      html += '<li><a href="' + escapeHTML(safeURL(l.url, { allowRelative: false })) + '" target="_blank" rel="noopener noreferrer">' + escapeHTML(l.title) + '</a></li>';
-    });
-    ul.innerHTML = sanitizeHTML(html);
-  }).catch(() => {});
-}
-
 // 排序切换
 document.querySelectorAll('.tab').forEach(tab => {
   tab.addEventListener('click', function() {

--- a/js/user.js
+++ b/js/user.js
@@ -19,6 +19,7 @@ async function renderUserProfile(username) {
 
     const result = await apiFetch('/posts?user_id=' + user.id + '&page=1&limit=100');
     const posts = result.data || [];
+    const postCount = result.pagination?.total || posts.length;
 
     const avatar = user.avatar_url || 'https://ui-avatars.com/api/?name=' + encodeURIComponent(user.username) + '&background=6366f1&color=fff&size=128';
 
@@ -29,7 +30,7 @@ async function renderUserProfile(username) {
         <p style="color:var(--text-secondary);font-size:14px;">${escapeHTML(user.bio || '这个人很懒，什么都没写')}</p>
         <div style="display:flex;justify-content:center;gap:32px;margin-top:16px;font-size:14px;color:var(--text-secondary);flex-wrap:wrap;">
           <span>📅 加入于 ${user.created_at ? new Date(user.created_at).toLocaleDateString('zh-CN') : '未知'}</span>
-          <span>📝 发了 ${posts.length} 个帖子</span>
+          <span>📝 发了 ${postCount} 个帖子</span>
           ${user.role === 'admin' ? '<span style="color:var(--primary);font-weight:600;">🛡️ 管理员</span>' : ''}
         </div>
         ${currentUser && currentUser.id !== user.id ? `

--- a/server.js
+++ b/server.js
@@ -1286,7 +1286,7 @@ app.get('/api/admin/custom-pages', auth, admin, async (req, res) => {
 
 // 创建自定义页面（管理员）
 app.post('/api/admin/custom-pages', auth, admin, async (req, res) => {
-  const { name, title, content } = req.body;
+  const { name, title, content, enabled = true } = req.body;
   if (!name || !title || !content) {
     return res.status(400).json({ error: '请填写完整信息' });
   }
@@ -1295,10 +1295,10 @@ app.post('/api/admin/custom-pages', auth, admin, async (req, res) => {
   }
   try {
     const r = await pool.query(
-      `INSERT INTO custom_pages (name, title, content)
-       VALUES ($1, $2, $3)
+      `INSERT INTO custom_pages (name, title, content, enabled)
+       VALUES ($1, $2, $3, $4)
        RETURNING *`,
-      [name, title, content]
+      [name, title, content, Boolean(enabled)]
     );
     res.json(r.rows[0]);
   } catch (err) {


### PR DESCRIPTION
## Summary
- surface JSON, HTML, proxy, and empty HTTP errors consistently
- make browser history push, replace, or skip entries explicitly
- prevent `popstate` and Back buttons from creating duplicate history entries
- use pagination totals for profile/settings post counts
- replace the destructive `View recovery codes` action with honest generate/replace behavior
- preserve enabled state when creating custom pages
- remove duplicate pin and feed helper implementations

## Validation
- all JavaScript syntax and diff checks pass
- API runtime tests cover JSON and non-JSON failures
- navigation runtime tests cover push, replace, no-history, and feed transitions
- source assertions verify `popstate` never pushes, Back buttons have no inline handlers, and only one pin method remains