### PR TITLE
Improve accessibility and i18n resilience

### DIFF
--- a/index.html
+++ b/index.html
@@ -21,15 +21,20 @@
   <script src="https://cdn.jsdelivr.net/npm/marked/marked.min.js"></script>
   <link rel="stylesheet" href="style.css" />
 </head>
-<body style="opacity:0;">
+<body>
 
   <!-- ===== 导航栏 ===== -->
   <nav id="navbar">
     <div class="nav-left">
-      <span id="forumName" class="forum-name">Forumlify</span>
+      <span id="forumName" class="forum-name" role="button" tabindex="0" aria-label="返回论坛首页">Forumlify</span>
       <span id="customNavLinks" style="display:inline-flex;align-items:center;gap:6px;margin-left:16px;"></span>
     </div>
     <div class="nav-right">
+      <label class="sr-only" for="languageSelect">语言 / Language</label>
+      <select id="languageSelect" aria-label="语言 / Language" class="language-select">
+        <option value="zh">中文</option>
+        <option value="en">English</option>
+      </select>
       <div id="userMenu">
         <div id="authButtons">
           <button id="loginBtn" class="btn-ghost">登录</button>
@@ -38,10 +43,10 @@
         <div id="userDropdown" style="display:none">
           <button id="messageBtn" class="nav-icon-btn" title="私信" style="position:relative;padding:6px 8px;background:none;border:none;cursor:pointer;color:var(--text-secondary);border-radius:4px;display:inline-flex;align-items:center;justify-content:center;">
             <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
-            <span id="messageBadge" style="display:none;position:absolute;top:-2px;right:-2px;background:#ef4444;color:#fff;border-radius:50%;padding:2px 6px;font-size:10px;font-weight:600;min-width:18px;text-align:center;line-height:1.4;"></span>
+            <span id="messageBadge" aria-live="polite" aria-atomic="true" style="display:none;position:absolute;top:-2px;right:-2px;background:#ef4444;color:#fff;border-radius:50%;padding:2px 6px;font-size:10px;font-weight:600;min-width:18px;text-align:center;line-height:1.4;"></span>
           </button>
-          <img id="avatarImg" class="avatar" src="" alt="avatar" />
-          <div class="dropdown-menu" id="dropdownMenu">
+          <img id="avatarImg" class="avatar" src="" alt="打开用户菜单" role="button" tabindex="0" aria-haspopup="menu" aria-expanded="false" />
+          <div class="dropdown-menu" id="dropdownMenu" role="menu">
             <a href="#" data-page="messages">
               <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
               消息
@@ -252,7 +257,7 @@
     <div style="max-width:600px;margin:0 auto;width:100%;">
       <input type="text" id="postTitle" placeholder="标题" style="width:100%;padding:10px 14px;border:1.5px solid #e2e8f0;border-radius:6px;font-size:15px;font-weight:600;margin-bottom:12px;font-family:inherit;" />
       <textarea id="postContent" rows="6" placeholder="说点什么..." style="width:100%;padding:12px;border:1.5px solid #e2e8f0;border-radius:6px;font-size:15px;font-family:inherit;resize:vertical;"></textarea>
-      <div id="dropZone" style="border:2px dashed var(--border);border-radius:8px;padding:24px;text-align:center;cursor:pointer;transition:all 0.3s;margin:8px 0 12px;background:var(--bg);">
+      <div id="dropZone" role="button" tabindex="0" aria-controls="fileInput" aria-label="选择或拖拽图片上传" style="border:2px dashed var(--border);border-radius:8px;padding:24px;text-align:center;cursor:pointer;transition:all 0.3s;margin:8px 0 12px;background:var(--bg);">
         <svg xmlns="http://www.w3.org/2000/svg" width="32" height="32" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:block;margin:0 auto 8px;color:var(--text-secondary);"><rect x="3" y="3" width="18" height="18" rx="2" ry="2"/><circle cx="8.5" cy="8.5" r="1.5"/><polyline points="21 15 16 10 5 21"/></svg>
         <p style="color:var(--text-secondary);font-size:14px;margin:0;">
           <span id="dropZoneText">点击或拖拽上传图片</span>
@@ -262,7 +267,7 @@
       </div>
       <div id="imagePreview" style="display:flex;flex-wrap:wrap;gap:8px;margin:8px 0;"></div>
       <div class="captcha-row" style="margin:12px 0;">
-        <span id="postCaptchaQuestion">3 + 5 = ?</span>
+        <span id="postCaptchaQuestion" role="button" tabindex="0" aria-label="刷新发帖验证码">3 + 5 = ?</span>
         <input type="text" id="postCaptchaInput" placeholder="答案" style="width:80px;padding:8px 12px;border:1px solid #e2e8f0;border-radius:4px;" />
       </div>
       <button id="postSubmit" class="btn-primary" style="padding:10px 32px;font-size:15px;">发布帖子</button>
@@ -312,7 +317,7 @@
           </h3>
           <textarea id="replyContent" rows="3" placeholder="写下你的回复..." style="width:100%;padding:12px 16px;background:rgba(255,255,255,0.1);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);border:1px solid var(--glass-border);border-radius:var(--radius-sm);font-size:14px;font-family:inherit;resize:vertical;color:var(--glass-text);transition:all var(--transition);"></textarea>
           <div class="captcha-row" style="margin:10px 0;">
-            <span id="replyCaptchaQuestion">3 + 5 = ?</span>
+            <span id="replyCaptchaQuestion" role="button" tabindex="0" aria-label="刷新回复验证码">3 + 5 = ?</span>
             <input type="text" id="replyCaptchaInput" placeholder="答案" style="width:80px;padding:8px 12px;background:rgba(255,255,255,0.12);backdrop-filter:blur(8px);-webkit-backdrop-filter:blur(8px);border:1px solid var(--glass-border);border-radius:var(--radius-sm);color:var(--glass-text);" />
           </div>
           <button id="replySubmit" class="btn-primary" style="padding:8px 24px;">提交回复</button>
@@ -363,7 +368,7 @@
       <input type="email" id="regEmail" placeholder="邮箱" />
       <input type="password" id="regPassword" placeholder="密码（至少6位）" />
       <div class="captcha-row">
-        <span id="regCaptchaQuestion">3 + 5 = ?</span>
+        <span id="regCaptchaQuestion" role="button" tabindex="0" aria-label="刷新注册验证码">3 + 5 = ?</span>
         <input type="text" id="regCaptchaInput" placeholder="答案" style="width:80px;" />
       </div>
       <button id="registerSubmit" class="btn-primary" style="width:100%;">注册</button>

--- a/js/app.js
+++ b/js/app.js
@@ -10,6 +10,9 @@ function showToast(message, type = 'success', duration = 3000) {
 
   const toast = document.createElement('div');
   toast.className = 'toast ' + type;
+  toast.setAttribute('role', type === 'error' ? 'alert' : 'status');
+  toast.setAttribute('aria-live', type === 'error' ? 'assertive' : 'polite');
+  toast.setAttribute('aria-atomic', 'true');
 
   const icons = {
     success: `<svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="#22c55e" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M22 11.08V12a10 10 0 1 1-5.93-9.14"/><polyline points="22 4 12 14.01 9 11.01"/></svg>`,
@@ -35,6 +38,112 @@ function showToast(message, type = 'success', duration = 3000) {
 }
 let currentPage = 'feed';
 let currentPageNum = 1;
+
+function makeKeyboardActivatable(element) {
+  if (!element || element.dataset.keyboardReady === 'true') return;
+  element.dataset.keyboardReady = 'true';
+  element.addEventListener('keydown', event => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      element.click();
+    }
+  });
+}
+
+function setupAccessibleModals() {
+  let returnFocusTo = null;
+
+  function enhanceModal(modal) {
+    if (!modal?.classList?.contains('modal') || modal.dataset.a11yReady === 'true') return;
+    modal.dataset.a11yReady = 'true';
+    modal.setAttribute('role', 'dialog');
+    modal.setAttribute('aria-modal', 'true');
+    modal.setAttribute('aria-hidden', modal.classList.contains('active') ? 'false' : 'true');
+
+    const content = modal.querySelector('.modal-content');
+    if (content) content.tabIndex = -1;
+
+    const heading = modal.querySelector('h1, h2, h3');
+    if (heading) {
+      if (!heading.id) heading.id = modal.id ? modal.id + 'Title' : 'dialogTitle' + Date.now();
+      modal.setAttribute('aria-labelledby', heading.id);
+    }
+
+    modal.querySelectorAll('.close').forEach(close => {
+      close.setAttribute('role', 'button');
+      close.setAttribute('tabindex', '0');
+      close.setAttribute('aria-label', '关闭对话框');
+      makeKeyboardActivatable(close);
+    });
+
+    if (modal.classList.contains('active')) {
+      returnFocusTo = document.activeElement;
+      requestAnimationFrame(() => content?.focus());
+    }
+  }
+
+  document.querySelectorAll('.modal').forEach(enhanceModal);
+  const observer = new MutationObserver(mutations => {
+    for (const mutation of mutations) {
+      if (mutation.type === 'childList') {
+        mutation.addedNodes.forEach(node => {
+          if (node.nodeType !== Node.ELEMENT_NODE) return;
+          if (node.matches?.('.modal')) enhanceModal(node);
+          node.querySelectorAll?.('.modal').forEach(enhanceModal);
+        });
+      }
+      if (mutation.type === 'attributes' && mutation.target.classList.contains('modal')) {
+        const modal = mutation.target;
+        const isOpen = modal.classList.contains('active');
+        modal.setAttribute('aria-hidden', isOpen ? 'false' : 'true');
+        if (isOpen) {
+          returnFocusTo = document.activeElement;
+          requestAnimationFrame(() => modal.querySelector('.modal-content')?.focus());
+        } else if (returnFocusTo?.isConnected) {
+          returnFocusTo.focus();
+          returnFocusTo = null;
+        }
+      }
+    }
+  });
+  observer.observe(document.body, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ['class']
+  });
+
+  document.addEventListener('keydown', event => {
+    const activeModal = Array.from(document.querySelectorAll('.modal.active')).at(-1);
+    if (!activeModal) return;
+
+    if (event.key === 'Escape') {
+      event.preventDefault();
+      activeModal.classList.remove('active');
+      return;
+    }
+
+    if (event.key === 'Tab') {
+      const focusable = Array.from(activeModal.querySelectorAll(
+        'a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex="-1"])'
+      )).filter(element => element.offsetParent !== null);
+      if (focusable.length === 0) {
+        event.preventDefault();
+        activeModal.querySelector('.modal-content')?.focus();
+        return;
+      }
+      const first = focusable[0];
+      const last = focusable[focusable.length - 1];
+      if (event.shiftKey && document.activeElement === first) {
+        event.preventDefault();
+        last.focus();
+      } else if (!event.shiftKey && document.activeElement === last) {
+        event.preventDefault();
+        first.focus();
+      }
+    }
+  });
+}
 
 function renderNav() {
   const authBtns = document.getElementById('authButtons');
@@ -1080,6 +1189,13 @@ function openImageViewer(imageUrl) {
 // ============================================================
 async function init() {
   applyTheme();
+  setupAccessibleModals();
+  document.querySelectorAll('input[placeholder], textarea[placeholder]').forEach(field => {
+    if (!field.hasAttribute('aria-label')) field.setAttribute('aria-label', field.placeholder);
+  });
+  document.querySelectorAll('#dropdownMenu a').forEach(item => {
+    item.setAttribute('role', 'menuitem');
+  });
 
   document.getElementById('forumName').textContent = CONFIG.FORUM_NAME || 'Forumlify';
 
@@ -1144,12 +1260,17 @@ async function init() {
     });
   }
 
-  document.getElementById('avatarImg').addEventListener('click', function(e) {
+  const avatarTrigger = document.getElementById('avatarImg');
+  makeKeyboardActivatable(avatarTrigger);
+  avatarTrigger.addEventListener('click', function(e) {
     e.stopPropagation();
-    document.getElementById('dropdownMenu').classList.toggle('show');
+    const menu = document.getElementById('dropdownMenu');
+    const expanded = menu.classList.toggle('show');
+    this.setAttribute('aria-expanded', String(expanded));
   });
   document.addEventListener('click', function() {
     document.getElementById('dropdownMenu').classList.remove('show');
+    avatarTrigger.setAttribute('aria-expanded', 'false');
   });
 
   document.querySelectorAll('[data-page]').forEach(el => {
@@ -1171,7 +1292,9 @@ async function init() {
     });
   });
 
-  document.getElementById('forumName').addEventListener('click', function() {
+  const forumName = document.getElementById('forumName');
+  makeKeyboardActivatable(forumName);
+  forumName.addEventListener('click', function() {
     switchPage('feed');
   });
 
@@ -1258,6 +1381,9 @@ async function init() {
   document.getElementById('regCaptchaQuestion').addEventListener('click', function() {
     refreshCaptcha('reg');
   });
+  ['postCaptchaQuestion', 'regCaptchaQuestion', 'replyCaptchaQuestion'].forEach(id => {
+    makeKeyboardActivatable(document.getElementById(id));
+  });
 
   // ===== 拖拽上传 =====
   const dropZone = document.getElementById('dropZone');
@@ -1265,6 +1391,7 @@ async function init() {
   const dropZoneText = document.getElementById('dropZoneText');
 
   if (dropZone && fileInput) {
+    makeKeyboardActivatable(dropZone);
     dropZone.addEventListener('click', function() {
       fileInput.click();
     });

--- a/js/feed.js
+++ b/js/feed.js
@@ -38,7 +38,7 @@ function renderFeed() {
       if (p.images && p.images.length > 0) {
         imagesHtml = '<div class="post-images">';
         p.images.forEach(img => {
-          imagesHtml += '<img src="' + escapeHTML(safeURL(img, { image: true })) + '" class="post-image" style="cursor:pointer;" />';
+          imagesHtml += '<img src="' + escapeHTML(safeURL(img, { image: true })) + '" class="post-image" alt="帖子图片" role="button" tabindex="0" style="cursor:pointer;" />';
         });
         imagesHtml += '</div>';
       }
@@ -61,8 +61,8 @@ function renderFeed() {
         <div class="post-card" data-postid="${p.id}" style="cursor:pointer;">
           ${p.is_pinned ? '<div style="font-size:12px;color:var(--primary);font-weight:600;margin-bottom:4px;">📌 置顶</div>' : ''}
           <div class="post-header">
-            <img src="${escapeHTML(safeURL(avatar, { image: true }))}" class="post-avatar" />
-            <span class="post-username" data-username="${escapeHTML(username)}" style="cursor:pointer;color:var(--primary);">${escapeHTML(username)}</span>
+            <img src="${escapeHTML(safeURL(avatar, { image: true }))}" class="post-avatar" alt="${escapeHTML(username)} 的头像" />
+            <span class="post-username" data-username="${escapeHTML(username)}" role="button" tabindex="0" style="cursor:pointer;color:var(--primary);">${escapeHTML(username)}</span>
             <span class="post-time">${time}</span>
             ${p.edited_at ? '<span style="font-size:11px;color:var(--text-light);margin-left:6px;">（已编辑）</span>' : ''}
           </div>
@@ -168,6 +168,7 @@ function renderFeed() {
     });
 
     container.querySelectorAll('.post-username').forEach(username => {
+      makeKeyboardActivatable(username);
       username.addEventListener('click', function(e) {
         e.stopPropagation();
         switchPage('user', this.dataset.username);
@@ -175,6 +176,7 @@ function renderFeed() {
     });
 
     container.querySelectorAll('.post-image').forEach(image => {
+      makeKeyboardActivatable(image);
       image.addEventListener('click', function(e) {
         e.stopPropagation();
         openImageViewer(this.src);

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -577,12 +577,15 @@ function detectLanguage() {
 }
 
 let currentLang = detectLanguage();
+let translationObserver = null;
 
 function setLanguage(lang) {
-  if (!TRANSLATIONS[lang]) return;
-  currentLang = lang;
+  if (!TRANSLATIONS[lang] || lang === currentLang) return;
   localStorage.setItem('forumlify-lang', lang);
-  applyTranslation();
+  const url = new URL(window.location.href);
+  url.searchParams.set('lang', lang);
+  window.history.replaceState(window.history.state, '', url);
+  window.location.reload();
 }
 
 function t(key) {
@@ -626,16 +629,18 @@ function applyTranslation() {
   walk(document.body);
 
   // 监听动态内容
-  const observer = new MutationObserver((mutations) => {
-    for (const mutation of mutations) {
-      for (const node of mutation.addedNodes) {
-        if (node.nodeType === Node.ELEMENT_NODE) {
-          walk(node);
+  if (!translationObserver) {
+    translationObserver = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            walk(node);
+          }
         }
       }
-    }
-  });
-  observer.observe(document.body, { childList: true, subtree: true });
+    });
+    translationObserver.observe(document.body, { childList: true, subtree: true });
+  }
 }
 
 // ============================================================
@@ -643,13 +648,11 @@ function applyTranslation() {
 // ============================================================
 
 document.addEventListener('DOMContentLoaded', function() {
-  document.body.style.opacity = '0';
-  setTimeout(function() {
-    if (typeof loadForumName === 'function') {
-      loadForumName();
-    }
-    applyTranslation();
-    document.body.style.transition = 'opacity 0.2s ease';
-    document.body.style.opacity = '1';
-  }, 200);
+  document.documentElement.lang = currentLang === 'zh' ? 'zh-CN' : 'en';
+  const selector = document.getElementById('languageSelect');
+  if (selector) {
+    selector.value = currentLang;
+    selector.addEventListener('change', event => setLanguage(event.target.value));
+  }
+  applyTranslation();
 });

--- a/js/post.js
+++ b/js/post.js
@@ -49,7 +49,7 @@ async function renderPostDetail(postId) {
     if (post.images && post.images.length > 0) {
       imagesHtml = '<div class="post-images">';
       post.images.forEach(img => {
-        imagesHtml += '<img src="' + escapeHTML(safeURL(img, { image: true })) + '" class="post-image" style="cursor:pointer;" />';
+        imagesHtml += '<img src="' + escapeHTML(safeURL(img, { image: true })) + '" class="post-image" alt="帖子图片" role="button" tabindex="0" style="cursor:pointer;" />';
       });
       imagesHtml += '</div>';
     }
@@ -70,8 +70,8 @@ async function renderPostDetail(postId) {
     let html = `
       <div class="post-detail-card">
         <div class="post-header">
-          <img src="${escapeHTML(safeURL(avatar, { image: true }))}" class="post-avatar" />
-          <span class="post-username" data-username="${escapeHTML(username)}" style="cursor:pointer;color:var(--primary);">${escapeHTML(username)}</span>
+          <img src="${escapeHTML(safeURL(avatar, { image: true }))}" class="post-avatar" alt="${escapeHTML(username)} 的头像" />
+          <span class="post-username" data-username="${escapeHTML(username)}" role="button" tabindex="0" style="cursor:pointer;color:var(--primary);">${escapeHTML(username)}</span>
           <span class="post-time">${time}</span>
           ${post.edited_at ? `<span style="font-size:12px;color:var(--text-light);margin-left:8px;">（已编辑 ${new Date(post.edited_at).toLocaleString('zh-CN')}）</span>` : ''}
           ${post.is_pinned ? '<span style="font-size:12px;color:var(--primary);margin-left:8px;">📌 置顶</span>' : ''}
@@ -111,8 +111,8 @@ async function renderPostDetail(postId) {
         html += `
           <div class="reply-item" data-replyid="${r.id}">
             <div class="reply-header">
-              <img src="${escapeHTML(safeURL(rAvatar, { image: true }))}" class="reply-avatar" />
-              <span class="reply-username" data-username="${escapeHTML(rUsername)}" style="cursor:pointer;color:var(--primary);">${escapeHTML(rUsername)}</span>
+              <img src="${escapeHTML(safeURL(rAvatar, { image: true }))}" class="reply-avatar" alt="${escapeHTML(rUsername)} 的头像" />
+              <span class="reply-username" data-username="${escapeHTML(rUsername)}" role="button" tabindex="0" style="cursor:pointer;color:var(--primary);">${escapeHTML(rUsername)}</span>
               <span class="reply-time">${rTime}</span>
               ${currentUser && (currentUser.id === r.user_id || currentUser.role === 'admin') ? `<button class="btn-sm btn-danger reply-delete-btn" data-replyid="${r.id}">
                 <svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" style="display:inline;vertical-align:middle;"><polyline points="3 6 5 6 21 6"/><path d="M19 6v14a2 2 0 0 1-2 2H7a2 2 0 0 1-2-2V6m3 0V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2"/></svg>
@@ -134,12 +134,14 @@ async function renderPostDetail(postId) {
     refreshCaptcha('reply');
 
     container.querySelectorAll('.post-username, .reply-username').forEach(usernameEl => {
+      makeKeyboardActivatable(usernameEl);
       usernameEl.addEventListener('click', function() {
         switchPage('user', this.dataset.username);
       });
     });
 
     container.querySelectorAll('.post-image').forEach(image => {
+      makeKeyboardActivatable(image);
       image.addEventListener('click', function() {
         openImageViewer(this.src);
       });

--- a/js/user.js
+++ b/js/user.js
@@ -24,7 +24,7 @@ async function renderUserProfile(username) {
 
     let html = `
       <div style="background:var(--surface);border:1px solid var(--border);border-radius:8px;padding:32px;text-align:center;">
-        <img src="${escapeHTML(safeURL(avatar, { image: true }))}" style="width:96px;height:96px;border-radius:50%;object-fit:cover;border:3px solid var(--primary);" />
+        <img src="${escapeHTML(safeURL(avatar, { image: true }))}" alt="${escapeHTML(user.username)} 的头像" style="width:96px;height:96px;border-radius:50%;object-fit:cover;border:3px solid var(--primary);" />
         <h2 style="margin:16px 0 4px;font-size:24px;">${escapeHTML(user.username)}</h2>
         <p style="color:var(--text-secondary);font-size:14px;">${escapeHTML(user.bio || '这个人很懒，什么都没写')}</p>
         <div style="display:flex;justify-content:center;gap:32px;margin-top:16px;font-size:14px;color:var(--text-secondary);flex-wrap:wrap;">
@@ -48,7 +48,7 @@ async function renderUserProfile(username) {
       posts.forEach(p => {
         const time = p.created_at ? new Date(p.created_at).toLocaleString('zh-CN') : '';
         html += `
-          <div class="post-card" data-postid="${escapeHTML(p.id)}" style="cursor:pointer;">
+          <div class="post-card" data-postid="${escapeHTML(p.id)}" role="link" tabindex="0" style="cursor:pointer;">
             <div class="post-title" style="font-size:16px;font-weight:600;">${escapeHTML(p.title || '无标题')}</div>
             <div class="post-content" style="font-size:14px;color:var(--text-secondary);">${escapeHTML((p.content || '').substring(0, 100))}${(p.content || '').length > 100 ? '...' : ''}</div>
             <div style="font-size:12px;color:var(--text-light);margin-top:8px;">${time}</div>
@@ -60,6 +60,7 @@ async function renderUserProfile(username) {
     container.innerHTML = sanitizeHTML(html);
 
     container.querySelectorAll('.post-card[data-postid]').forEach(card => {
+      makeKeyboardActivatable(card);
       card.addEventListener('click', function() {
         switchToPost(this.dataset.postid);
       });

--- a/style.css
+++ b/style.css
@@ -2527,3 +2527,39 @@ a.btn-secondary {
    ============================================================ */
 
 
+/* Accessibility helpers */
+.sr-only {
+  position: absolute !important;
+  width: 1px !important;
+  height: 1px !important;
+  padding: 0 !important;
+  margin: -1px !important;
+  overflow: hidden !important;
+  clip: rect(0, 0, 0, 0) !important;
+  white-space: nowrap !important;
+  border: 0 !important;
+}
+
+.language-select {
+  border: 1px solid var(--glass-border);
+  border-radius: 6px;
+  padding: 5px 8px;
+  background: var(--glass-bg);
+  color: var(--glass-text);
+  font: inherit;
+}
+
+:where(a, button, input, select, textarea, [role="button"], [tabindex]):focus-visible {
+  outline: 3px solid #f59e0b !important;
+  outline-offset: 3px !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  *, *::before, *::after {
+    scroll-behavior: auto !important;
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+  }
+}
+


### PR DESCRIPTION
## Summary
- keep the page visible if translation JavaScript fails
- add a persistent Chinese/English language selector and update document language
- avoid duplicate translation observers and reload from source when switching languages
- add keyboard activation for logo, avatar menu, uploads, CAPTCHA refresh, usernames, images, and profile posts
- add dialog roles, accessible names, focus movement/restoration, Escape close, and Tab trapping
- add live regions for toast/unread status and accessible placeholder labels
- add visible focus indicators and reduced-motion support
- add alternative text to generated avatars and post images

## Validation
- all JavaScript syntax and diff checks pass
- 18 static accessibility/i18n assertions pass
- real jsdom runtime test verifies dialog semantics, keyboard activation, focus transfer/restoration, and Escape closing
- source checks verify language selector, single observer, live regions, focus styling, and reduced-motion rules