### PR TITLE
Verify CAPTCHA challenges on the server

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,8 @@ psql -U forumlify -d forumlify -f schema.sql
 | `DATABASE_URL` | `postgresql://forumlify:***@localhost:5432/forumlify` | PostgreSQL 连接串 |
 | `PORT` | `3000` | HTTP 监听端口 |
 | `JWT_SECRET` | 本地开发使用内置值 | JWT 签名密钥；`NODE_ENV=production` 时必须显式设置 |
+| `CAPTCHA_SECRET` | 与 `JWT_SECRET` 相同 | 验证码答案 HMAC 密钥；生产环境可单独设置强随机值 |
+| `ENABLE_CAPTCHA` | `true` | 设为 `false` 可关闭注册、发帖和回复的服务器验证码校验 |
 | `ALLOWED_ORIGINS` | 空 | 允许跨域访问的来源，多个值用逗号分隔；为空时仅支持同源访问 |
 | `TRUST_PROXY` | `false` | 位于可信反向代理后时设为 `true`，用于正确识别限流 IP |
 
@@ -102,7 +104,7 @@ npm start
 | 配置项 | 默认值 | 说明 |
 |--------|--------|------|
 | `FORUM_NAME` | `Forumlify` | 论坛名称（左上角显示） |
-| `ENABLE_CAPTCHA` | `true` | 发帖/注册的人机验证（10 以内加减法） |
+| `ENABLE_CAPTCHA` | `true` | 注册、发帖和回复的服务器验证一次性算术挑战 |
 | `SERVER_PORT` | `null` | 可选：服务端监听端口。优先级：环境变量 `PORT` > `SERVER_PORT` > 默认 `3000` |
 
 #### 上传目录

--- a/js/api.js
+++ b/js/api.js
@@ -19,6 +19,12 @@ function apiFetch(path, options = {}) {
 }
 
 const API = {
+  async getCaptcha(context) {
+    const data = await apiFetch('/captcha?context=' + encodeURIComponent(context));
+    if (data.error) throw new Error(data.error);
+    return data;
+  },
+
   // ============================================================
   //  认证
   // ============================================================
@@ -35,10 +41,16 @@ const API = {
     return data;
   },
 
-  async register(email, password, username) {
+  async register(email, password, username, captcha) {
     const data = await apiFetch('/auth/register', {
       method: 'POST',
-      body: JSON.stringify({ email, password, username })
+      body: JSON.stringify({
+        email,
+        password,
+        username,
+        captcha_id: captcha?.id,
+        captcha_answer: captcha?.answer
+      })
     });
     if (data.error) throw new Error(data.error);
     return data;
@@ -71,10 +83,16 @@ const API = {
     return data;
   },
 
-  async createPost(title, content, images) {
+  async createPost(title, content, images, captcha) {
     const data = await apiFetch('/posts', {
       method: 'POST',
-      body: JSON.stringify({ title, content, images: images || [] })
+      body: JSON.stringify({
+        title,
+        content,
+        images: images || [],
+        captcha_id: captcha?.id,
+        captcha_answer: captcha?.answer
+      })
     });
     if (data.error) throw new Error(data.error);
     return data;
@@ -112,10 +130,14 @@ const API = {
     return data || [];
   },
 
-  async createReply(postId, content) {
+  async createReply(postId, content, captcha) {
     const data = await apiFetch('/posts/' + postId + '/replies', {
       method: 'POST',
-      body: JSON.stringify({ content })
+      body: JSON.stringify({
+        content,
+        captcha_id: captcha?.id,
+        captcha_answer: captcha?.answer
+      })
     });
     if (data.error) throw new Error(data.error);
     return data;

--- a/js/app.js
+++ b/js/app.js
@@ -1232,16 +1232,15 @@ async function init() {
     }
     const title = document.getElementById('postTitle').value.trim() || '无标题';
     const content = document.getElementById('postContent').value.trim();
-    const captchaInput = document.getElementById('postCaptchaInput').value.trim();
-    const captchaAnswer = parseInt(document.getElementById('postCaptchaInput').dataset.answer);
+    const captcha = getCaptchaSubmission('post');
     if (!content) { alert('请填写内容'); return; }
-    if (parseInt(captchaInput) !== captchaAnswer) { alert('验证码错误，请重新计算'); refreshCaptcha('post'); return; }
+    if (!captcha) { alert('请填写验证码'); return; }
     const images = [];
     document.querySelectorAll('#imagePreview img').forEach(img => {
       images.push(img.src);
     });
     try {
-      await API.createPost(title, content, images);
+      await API.createPost(title, content, images, captcha);
       API.logEvent('create_post').catch(() => {});
       alert('发布成功！');
       switchPage('feed');
@@ -1249,6 +1248,7 @@ async function init() {
       renderStats();
     } catch (err) {
       alert('发布失败：' + err.message);
+      refreshCaptcha('post');
     }
   });
 

--- a/js/auth.js
+++ b/js/auth.js
@@ -42,15 +42,15 @@ document.getElementById('registerSubmit').addEventListener('click', async () => 
   const username = document.getElementById('regUsername').value.trim();
   const email = document.getElementById('regEmail').value.trim();
   const password = document.getElementById('regPassword').value;
-  const captchaInput = document.getElementById('regCaptchaInput').value.trim();
-  const captchaAnswer = parseInt(document.getElementById('regCaptchaInput').dataset.answer);
+  const captcha = getCaptchaSubmission('reg');
   if (!username || !email || !password) { alert('请填写完整信息'); return; }
   if (password.length < 6) { alert('密码至少6位'); return; }
-  if (parseInt(captchaInput) !== captchaAnswer) { alert('验证码错误，请重新计算'); refreshCaptcha('reg'); return; }
+  if (!captcha) { alert('请填写验证码'); return; }
   try {
-    await API.register(email, password, username);
+    await API.register(email, password, username, captcha);
   } catch (err) {
     alert('注册失败：' + err.message);
+    refreshCaptcha('reg');
     return;
   }
 

--- a/js/captcha.js
+++ b/js/captcha.js
@@ -1,28 +1,62 @@
 // ============================================================
-//  🧠 验证码
+//  🧠 服务器验证的一次性验证码
 // ============================================================
 
-function generateCaptcha() {
-  let a = Math.floor(Math.random() * 9) + 1;
-  let b = Math.floor(Math.random() * 9) + 1;
-  let op = ['+', '-'][Math.floor(Math.random() * 2)];
-  if (op === '-' && a < b) { let t = a;
-    a = b;
-    b = t; }
-  let answer = op === '+' ? a + b : a - b;
-  return { question: a + ' ' + op + ' ' + b + ' = ?', answer: answer };
+const CAPTCHA_CONTEXTS = {
+  reg: 'registration',
+  post: 'post',
+  reply: 'reply'
+};
+
+const CAPTCHA_ELEMENTS = {
+  reg: ['regCaptchaQuestion', 'regCaptchaInput'],
+  post: ['postCaptchaQuestion', 'postCaptchaInput'],
+  reply: ['replyCaptchaQuestion', 'replyCaptchaInput']
+};
+
+async function refreshCaptcha(type) {
+  const context = CAPTCHA_CONTEXTS[type];
+  const elementIds = CAPTCHA_ELEMENTS[type];
+  if (!context || !elementIds) return;
+
+  const question = document.getElementById(elementIds[0]);
+  const input = document.getElementById(elementIds[1]);
+  if (!question || !input) return;
+
+  const row = question.closest('.captcha-row');
+  input.value = '';
+  input.dataset.challengeId = '';
+  input.dataset.captchaEnabled = 'true';
+  input.disabled = true;
+  question.textContent = '加载验证码...';
+  if (row) row.style.display = '';
+
+  try {
+    const challenge = await API.getCaptcha(context);
+    if (challenge.enabled === false) {
+      input.dataset.captchaEnabled = 'false';
+      if (row) row.style.display = 'none';
+      return;
+    }
+
+    input.dataset.challengeId = challenge.id;
+    question.textContent = challenge.question;
+    input.disabled = false;
+  } catch (error) {
+    question.textContent = '验证码加载失败，点击重试';
+    input.disabled = true;
+  }
 }
 
-function refreshCaptcha(type) {
-  let q = generateCaptcha();
-  if (type === 'reg') {
-    document.getElementById('regCaptchaQuestion').textContent = q.question;
-    document.getElementById('regCaptchaInput').dataset.answer = q.answer;
-  } else if (type === 'post') {
-    document.getElementById('postCaptchaQuestion').textContent = q.question;
-    document.getElementById('postCaptchaInput').dataset.answer = q.answer;
-  } else if (type === 'reply') {
-    document.getElementById('replyCaptchaQuestion').textContent = q.question;
-    document.getElementById('replyCaptchaInput').dataset.answer = q.answer;
-  }
+function getCaptchaSubmission(type) {
+  const elementIds = CAPTCHA_ELEMENTS[type];
+  if (!elementIds) return null;
+
+  const input = document.getElementById(elementIds[1]);
+  if (!input || input.dataset.captchaEnabled === 'false') return {};
+
+  const id = input.dataset.challengeId;
+  const answer = input.value.trim();
+  if (!id || !answer) return null;
+  return { id, answer };
 }

--- a/js/post.js
+++ b/js/post.js
@@ -222,12 +222,11 @@ async function renderPostDetail(postId) {
 async function handleReplySubmit(postId) {
   if (!currentUser) { alert('请先登录'); return; }
   const content = document.getElementById('replyContent').value.trim();
-  const captchaInput = document.getElementById('replyCaptchaInput').value.trim();
-  const captchaAnswer = parseInt(document.getElementById('replyCaptchaInput').dataset.answer);
+  const captcha = getCaptchaSubmission('reply');
   if (!content) { alert('请填写回复内容'); return; }
-  if (parseInt(captchaInput) !== captchaAnswer) { alert('验证码错误，请重新计算'); refreshCaptcha('reply'); return; }
+  if (!captcha) { alert('请填写验证码'); return; }
   try {
-    await API.createReply(postId, content);
+    await API.createReply(postId, content, captcha);
     API.logEvent('create_reply').catch(() => {});
     renderPostDetail(postId);
     if (currentPage === 'feed') {
@@ -236,5 +235,6 @@ async function handleReplySubmit(postId) {
     renderStats();
   } catch (err) {
     alert('回复失败：' + err.message);
+    refreshCaptcha('reply');
   }
 }

--- a/schema.sql
+++ b/schema.sql
@@ -193,6 +193,19 @@ CREATE TABLE IF NOT EXISTS recovery_codes (
 
 CREATE INDEX IF NOT EXISTS idx_recovery_codes_user_id ON recovery_codes(user_id);
 
+-- One-time, short-lived server-verified CAPTCHA challenges.
+CREATE TABLE IF NOT EXISTS captcha_challenges (
+  id UUID PRIMARY KEY,
+  context VARCHAR(20) NOT NULL CHECK (context IN ('registration', 'post', 'reply')),
+  answer_hash CHAR(64) NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,
+  used_at TIMESTAMPTZ,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_captcha_challenges_expires_at
+  ON captcha_challenges(expires_at);
+
 -- 帖子表添加置顶字段
 ALTER TABLE posts ADD COLUMN IF NOT EXISTS is_pinned BOOLEAN DEFAULT false;
 ALTER TABLE posts ADD COLUMN IF NOT EXISTS pinned_at TIMESTAMPTZ;

--- a/server.js
+++ b/server.js
@@ -13,6 +13,7 @@ const { Pool } = require('pg');
 const multer = require('multer');
 const path = require('path');
 const fs = require('fs');
+const crypto = require('crypto');
 
 const app = express();
 
@@ -23,6 +24,8 @@ const CONFIG = require('./config');
 const PORT = process.env.PORT || CONFIG.SERVER_PORT || 3000;
 const DEFAULT_JWT_SECRET = 'forumlify-secret-key-change-me-in-production';
 const JWT_SECRET = process.env.JWT_SECRET || DEFAULT_JWT_SECRET;
+const CAPTCHA_SECRET = process.env.CAPTCHA_SECRET || JWT_SECRET;
+const CAPTCHA_ENABLED = process.env.ENABLE_CAPTCHA !== 'false' && CONFIG.ENABLE_CAPTCHA !== false;
 
 if (process.env.NODE_ENV === 'production' && JWT_SECRET === DEFAULT_JWT_SECRET) {
   throw new Error('JWT_SECRET must be set to a unique value in production');
@@ -75,9 +78,17 @@ const authLimiter = rateLimit({
   legacyHeaders: false,
   handler: (req, res) => res.status(429).json({ error: '尝试次数过多，请稍后重试' }),
 });
+const captchaLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000,
+  limit: 60,
+  standardHeaders: 'draft-8',
+  legacyHeaders: false,
+  handler: (req, res) => res.status(429).json({ error: '验证码请求过于频繁，请稍后重试' }),
+});
 
 app.use('/api', apiLimiter);
 app.use(['/api/auth/login', '/api/auth/register', '/api/auth/reset-password'], authLimiter);
+app.use('/api/captcha', captchaLimiter);
 app.use(express.json({ limit: '100kb' }));
 app.use(express.urlencoded({ extended: true, limit: '100kb' }));
 
@@ -132,6 +143,98 @@ async function createNotification(userId, type, title, content, link = null) {
   }
 }
 
+function hashCaptchaAnswer(id, context, answer) {
+  return crypto
+    .createHmac('sha256', CAPTCHA_SECRET)
+    .update(`${id}:${context}:${answer}`)
+    .digest('hex');
+}
+
+function secureHashMatch(actual, expected) {
+  const actualBuffer = Buffer.from(String(actual));
+  const expectedBuffer = Buffer.from(String(expected));
+  return actualBuffer.length === expectedBuffer.length &&
+    crypto.timingSafeEqual(actualBuffer, expectedBuffer);
+}
+
+async function consumeCaptcha(challengeId, answer, context) {
+  if (!/^[0-9a-f-]{36}$/i.test(String(challengeId || '')) ||
+      !/^-?\d{1,3}$/.test(String(answer || '').trim())) {
+    return false;
+  }
+
+  const client = await pool.connect();
+  try {
+    await client.query('BEGIN');
+    const challenge = await client.query(
+      `SELECT id, context, answer_hash, expires_at, used_at
+       FROM captcha_challenges
+       WHERE id = $1
+       FOR UPDATE`,
+      [challengeId]
+    );
+    if (!challenge.rows[0] || challenge.rows[0].used_at) {
+      await client.query('ROLLBACK');
+      return false;
+    }
+
+    await client.query(
+      'UPDATE captcha_challenges SET used_at = NOW() WHERE id = $1',
+      [challengeId]
+    );
+    await client.query('COMMIT');
+
+    const row = challenge.rows[0];
+    const expected = hashCaptchaAnswer(challengeId, context, String(answer).trim());
+    return row.context === context && new Date(row.expires_at) > new Date() &&
+      secureHashMatch(row.answer_hash, expected);
+  } catch (error) {
+    await client.query('ROLLBACK').catch(() => {});
+    throw error;
+  } finally {
+    client.release();
+  }
+}
+
+async function requireCaptcha(req, res, context) {
+  if (!CAPTCHA_ENABLED) return true;
+  const valid = await consumeCaptcha(req.body.captcha_id, req.body.captcha_answer, context);
+  if (!valid) {
+    res.status(400).json({ error: '验证码无效或已过期，请重新计算' });
+    return false;
+  }
+  return true;
+}
+
+app.get('/api/captcha', async (req, res) => {
+  if (!CAPTCHA_ENABLED) return res.json({ enabled: false });
+  const context = req.query.context;
+  if (!['registration', 'post', 'reply'].includes(context)) {
+    return res.status(400).json({ error: '验证码场景无效' });
+  }
+
+  let left = crypto.randomInt(1, 10);
+  let right = crypto.randomInt(1, 10);
+  const operator = crypto.randomInt(0, 2) === 0 ? '+' : '-';
+  if (operator === '-' && left < right) [left, right] = [right, left];
+  const answer = operator === '+' ? left + right : left - right;
+  const id = crypto.randomUUID();
+  const expiresAt = new Date(Date.now() + 5 * 60 * 1000);
+  const answerHash = hashCaptchaAnswer(id, context, answer);
+
+  try {
+    await pool.query('DELETE FROM captcha_challenges WHERE expires_at < NOW() - INTERVAL \'1 hour\'');
+    await pool.query(
+      `INSERT INTO captcha_challenges (id, context, answer_hash, expires_at)
+       VALUES ($1, $2, $3, $4)`,
+      [id, context, answerHash, expiresAt]
+    );
+    return res.json({ id, question: `${left} ${operator} ${right} = ?`, expires_at: expiresAt });
+  } catch (error) {
+    return res.status(500).json({ error: '验证码生成失败' });
+  }
+});
+
 // ============================================================
 //  论坛设置接口
 // ============================================================
@@ -179,6 +282,12 @@ app.post('/api/auth/register', async (req, res) => {
   }
   if (password.length < 6) {
     return res.status(400).json({ error: '密码至少6位' });
+  }
+
+  try {
+    if (!await requireCaptcha(req, res, 'registration')) return;
+  } catch (error) {
+    return res.status(500).json({ error: '验证码验证失败' });
   }
 
   try {
@@ -565,6 +674,12 @@ app.post('/api/posts', auth, async (req, res) => {
   }
 
   try {
+    if (!await requireCaptcha(req, res, 'post')) return;
+  } catch (error) {
+    return res.status(500).json({ error: '验证码验证失败' });
+  }
+
+  try {
     const r = await pool.query(
       `INSERT INTO posts (user_id, title, content, images)
        VALUES ($1, $2, $3, $4)
@@ -696,6 +811,12 @@ app.post('/api/posts/:id/replies', auth, async (req, res) => {
 
   if (!content || content.trim().length === 0) {
     return res.status(400).json({ error: '请填写回复内容' });
+  }
+
+  try {
+    if (!await requireCaptcha(req, res, 'reply')) return;
+  } catch (error) {
+    return res.status(500).json({ error: '验证码验证失败' });
   }
 
   try {


### PR DESCRIPTION
## Summary
- replace browser-generated answers with server-issued one-time challenges
- store only HMAC answer hashes with five-minute expiry
- consume challenges atomically under a row lock, including incorrect attempts
- bind challenges to registration, post, or reply context
- enforce CAPTCHA on all three protected APIs
- add challenge-specific rate limiting and expired-row cleanup
- honor `ENABLE_CAPTCHA=false` consistently on server and browser

## Validation
- all JavaScript syntax and diff checks pass
- challenge creation/HMAC route test passes
- correct answer, replay, wrong answer, expiry, invalid context, and missing challenge tests pass
- source assertions confirm no expected answer or `Math.random` remains in browser code
- exactly three protected endpoint enforcement calls and three CAPTCHA payloads are present