### PR TITLE
docs: update repository links to forumlify/public

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Forumlify 提供了两个不同架构的分支版本，以满足不同部署环�
 
 ```bash
 # 本分支（NEXT 版）；如要部署 LITE 版请 clone main 分支
-git clone -b next https://github.com/furrium/forumlify.git
+git clone -b next https://github.com/forumlify/public.git
 cd forumlify
 docker-compose up -d
 ```
@@ -51,7 +51,7 @@ docker-compose up -d
 
 ```
 # 拉取最新镜像
-docker pull ghcr.io/furrium/forumlify:next
+docker pull ghcr.io/forumlify/public:next
 # 重启
 docker compose down && docker compose up -d
 ```
@@ -77,7 +77,7 @@ docker compose down && docker compose up -d
 
 ```bash
 # 克隆 next 分支（Next.js 版）；main 分支是 Express 版
-git clone -b next https://github.com/furrium/forumlify.git
+git clone -b next https://github.com/forumlify/public.git
 cd forumlify
 npm install
 ```

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Forumlify 提供了两个不同架构的分支版本，以满足不同部署环�
 ```bash
 # 本分支（NEXT 版）；如要部署 LITE 版请 clone main 分支
 git clone -b next https://github.com/forumlify/public.git
-cd forumlify
+cd public
 docker-compose up -d
 ```
 
@@ -78,7 +78,7 @@ docker compose down && docker compose up -d
 ```bash
 # 克隆 next 分支（Next.js 版）；main 分支是 Express 版
 git clone -b next https://github.com/forumlify/public.git
-cd forumlify
+cd public
 npm install
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
 
   app:
     # 从 GHCR 拉取镜像（每次 push next 自动重建），不再本地构建
-    image: ghcr.io/furrium/forumlify:next
+    image: ghcr.io/forumlify/public:next
     ports:
       - "3000:3000"
     depends_on:


### PR DESCRIPTION
## 目标分支 / Target branch

- [x] **next**（Next.js 16 版 / Next.js 16 version）

## 变更内容 / What does this PR do?

将 README 中所有旧仓库地址 `furrium/forumlify` 更新为新的 org 仓库地址 `forumlify/public`（仓库已迁移至 forumlify org）。

/ Update all old repository references from `furrium/forumlify` to the new org repo `forumlify/public` (the repository has moved to the forumlify org).

共 3 处 / 3 places:

1. Docker 快速开始的 `git clone` 地址 / `git clone` URL in Docker quick start
2. Docker 更新段的 `docker pull ghcr.io/forumlify/public:next`（镜像名由 workflow 的 `${{ github.repository }}` 动态生成，随仓库迁移自动变更）/ `docker pull ghcr.io/forumlify/public:next` (image name is generated from `${{ github.repository }}` in the workflow, so it follows the repo move)
3. 源码构建的 `git clone` 地址 / `git clone` URL in source build section

## 测试 / Testing

- [x] 已检查 README 中无残留的 `furrium/forumlify` 引用 / Verified no remaining `furrium/forumlify` references in README

## 检查清单 / Checklist

- [x] 我的代码遵循现有代码风格 / My code follows the existing code style
- [x] 本 PR 只包含必要的改动 / This PR contains only the necessary changes