### PR TITLE
feat: update app container after image pull

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,14 +47,13 @@ docker-compose up -d
 
 应用默认运行在 `http://localhost:3000`（监听 `0.0.0.0`，局域网可访问）。
 
-##Docker更新
+## Docker 更新
 
+```bash
+./scripts/update-docker.sh
 ```
-# 拉取最新镜像
-docker pull ghcr.io/forumlify/public:next
-# 重启
-docker compose down && docker compose up -d
-```
+
+更新脚本兼容 Docker Compose v2（`docker compose`）和 v1（`docker-compose`）。它会先拉取最新的 `app` 镜像，再让 Compose 在镜像发生变化时重新创建应用容器；数据库容器和数据卷不会重建。
 
 ---
 

--- a/scripts/update-docker.sh
+++ b/scripts/update-docker.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+set -Eeuo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$PROJECT_ROOT"
+
+if docker compose version >/dev/null 2>&1; then
+    compose=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+    compose=(docker-compose)
+else
+    echo "Docker Compose is required (docker compose or docker-compose)." >&2
+    exit 1
+fi
+
+echo "Pulling the latest Forumlify image..."
+"${compose[@]}" pull app
+
+echo "Applying the latest image to the Forumlify app container..."
+"${compose[@]}" up -d --no-deps app
+
+echo "Forumlify is now running with the latest image."
+"${compose[@]}" ps app


### PR DESCRIPTION
# 感谢你为 Forumlify 提交贡献！/ Thank you for contributing to Forumlify!

## 目标分支 / Target branch

- [ ] **Lite**（原生单文件版 / Original single-file version）
- [x] **next**（Next.js 16 版 / Next.js 16 version）

## 版本信息 / Version info

```
不适用 / Not applicable
```

## 变更内容 / What does this PR do?

- 新增 `scripts/update-docker.sh`，兼容 Docker Compose v2（`docker compose`）和 v1（`docker-compose`）。
- 更新时先拉取最新 `app` 镜像，再执行 `up -d --no-deps app`，由 Compose 在镜像变化时自动重新创建应用容器。
- 更新 README 的 Docker 更新说明。
- 不包含 `download/install.sh`。

/ Add a Docker update helper compatible with Compose v1 and v2. It pulls the latest app image and then runs `up -d --no-deps app`, allowing Compose to recreate the app when the image changes. The database container and volume are left untouched.

## 动机 / Motivation

当前只拉取镜像或重新启动的操作不够明确，容易继续使用旧容器。统一更新命令后，应用容器会根据镜像变化自动刷新，同时不重建数据库。

/ Make image updates deterministic while keeping the PostgreSQL container and volume intact.

## 测试 / Testing

- [ ] 本地构建通过 / Local build passes (`npm run build`，仅 next 分支 / next branch only)
- [x] 相关功能已手动测试 / Related features manually tested（使用模拟 Docker v1/v2 命令验证调用顺序 / mocked Docker v1/v2 command paths）
- [ ] 测试用例已更新 / Tests updated

## 截图 / Screenshots

不适用 / Not applicable（无 UI 改动 / no UI changes）

## 检查清单 / Checklist

- [ ] 我已阅读并遵循了贡献指南 / I have read and followed the contributing guidelines
- [x] 我的代码遵循现有代码风格 / My code follows the existing code style
- [x] 我已同步最新的上游分支 / I have synced with the latest upstream branch
- [x] 本 PR 只包含必要的改动 / This PR contains only the necessary changes